### PR TITLE
fix scroll when Antd table has a fixed columns on the left

### DIFF
--- a/src/hook.ts
+++ b/src/hook.ts
@@ -98,7 +98,11 @@ export const useTableTopScroll = ({ debugName }: Props) => {
     const wrapper = wrapperRef.current
     if (wrapper) {
       const innerTableDoms = wrapper.querySelectorAll(`table`)
-      const innerTableDom = innerTableDoms.length > 1 ? innerTableDoms[1] : innerTableDoms[0]
+      // Search for proper Table element in case of using fixed columns in Antd Table
+      const innerTableDom = (innerTableDoms.length>1 && innerTableDoms[1].parentElement!=undefined &&innerTableDoms[1].parentElement.className.indexOf("ant-table-body-inner")==-1 ) 
+                            ? innerTableDoms[1]
+                            : innerTableDoms[0] ;
+      //
       if (!innerTableDom) {
         if (debugName) {
           log(`"table" not found, make sure has antd Table component as children`)


### PR DESCRIPTION
Hi !
This PR is intended to fix that the top scroll  is not being created when the table has a fixed column on the left.
The problem was detected using Antd@3.26.3
Thanks!